### PR TITLE
Fix the MetaDataScanner.test.ts infinite recursion in its mock setup

### DIFF
--- a/src/services/package-manager/__tests__/MetadataScanner.test.ts
+++ b/src/services/package-manager/__tests__/MetadataScanner.test.ts
@@ -45,23 +45,6 @@ describe("MetadataScanner", () => {
 
 	describe("Basic Metadata Scanning", () => {
 		it("should discover components with English metadata", async () => {
-			// Mock directory structure
-			const mockDirents = [
-				{
-					name: "component1",
-					isDirectory: () => true,
-					isFile: () => false,
-				},
-				{
-					name: "metadata.en.yml",
-					isDirectory: () => false,
-					isFile: () => true,
-				},
-			] as Dirent[]
-
-			// For subdirectories, return empty to prevent infinite recursion
-			const mockEmptyDirents = [] as Dirent[]
-
 			// Setup mock implementations
 			const mockStats = {
 				isDirectory: () => true,
@@ -72,14 +55,39 @@ describe("MetadataScanner", () => {
 			// Mock fs.promises methods using type assertions
 			const mockedFs = jest.mocked(fs)
 			mockedFs.stat.mockResolvedValue(mockStats)
-			;(mockedFs.readdir as any).mockImplementation(async (path: any, options?: any) => {
-				// Return empty array for nested component1 directories to prevent recursion
-				if (path.toString().includes("/component1/")) {
-					return options?.withFileTypes ? mockEmptyDirents : []
+
+			// Define specific Dirent objects
+			const componentDirDirent: Dirent = {
+				name: "component1",
+				isDirectory: () => true,
+				isFile: () => false,
+			} as Dirent
+			const metadataFileDirent: Dirent = {
+				name: "metadata.en.yml",
+				isDirectory: () => false,
+				isFile: () => true,
+			} as Dirent
+
+			// Refined mock implementation for fs.readdir
+			;(mockedFs.readdir as any).mockImplementation(async (p: string, options?: any) => {
+				const normalizedP = normalizePath(p)
+				const normalizedBasePath = normalizePath(mockBasePath)
+				const normalizedComponentPath = normalizePath(path.join(mockBasePath, "component1"))
+
+				if (normalizedP === normalizedBasePath) {
+					// For the base path, return only the component directory
+					const baseDirents = [componentDirDirent]
+					return options?.withFileTypes ? baseDirents : baseDirents.map((d) => d.name)
+				} else if (normalizedP === normalizedComponentPath) {
+					// For the component1 directory, return only the metadata file
+					const componentDirents = [metadataFileDirent]
+					return options?.withFileTypes ? componentDirents : componentDirents.map((d) => d.name)
+				} else {
+					// For any other path (deeper recursion), return empty
+					return options?.withFileTypes ? [] : []
 				}
-				// Return full directory listing for base component1 directory
-				return options?.withFileTypes ? mockDirents : mockDirents.map((d) => d.name)
 			})
+
 			mockedFs.readFile.mockResolvedValue(
 				Buffer.from(`
 name: Test Component


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
